### PR TITLE
Use unveil(2) to limit execution to mount_*(8) and umount(8)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,8 +34,10 @@
 #include "manageradaptor.h"
 #include "objectmanager.h"
 
+#include <err.h>
 #include <iostream>
 #include <syslog.h>
+#include <unistd.h>
 
 #include <QSet>
 
@@ -84,6 +86,23 @@ static void msg_handler(QtMsgType type, const QMessageLogContext& context, const
 
 int main(int argc, char** argv)
 {
+    if (unveil("/", "rwc") == -1)
+        err(1, "unveil /");
+    if (unveil("/sbin/umount", "rx") == -1)
+        err(1, "unveil /sbin/umount");
+    if (unveil("/sbin/mount_ffs", "rx") == -1)
+        err(1, "unveil /sbin/mount_ffs");
+    if (unveil("/sbin/mount_ext2fs", "rx") == -1)
+        err(1, "unveil /sbin/mount_ext2fs");
+    if (unveil("/sbin/mount_ntfs", "rx") == -1)
+        err(1, "unveil /sbin/mount_ntfs");
+    if (unveil("/sbin/mount_msdos", "rx") == -1)
+        err(1, "unveil /sbin/mount_msdos");
+    if (unveil("/sbin/mount_cd9660", "rx") == -1)
+        err(1, "unveil /sbin/mount_cd9660");
+    if (unveil(NULL, NULL) == -1)
+        err(1, "unveil NULL");
+
     qInstallMessageHandler(msg_handler);
 
     qRegisterMetaType<Configuration>();


### PR DESCRIPTION
Uncovered hw.disknames sysctl(2) and cd(4) ioctl(2) prevents pledge(2) usage.
